### PR TITLE
bug(cryptopro-cades): Корректное определение наличия контейнера закрытого ключа сертификата

### DIFF
--- a/packages/cryptopro-cades/src/api/sign.ts
+++ b/packages/cryptopro-cades/src/api/sign.ts
@@ -24,6 +24,7 @@ import { unwrap } from './internal/unwrap';
  * @param {boolean} [detach=true] присоединять подпись к данным или отдельно?
  * @param {boolean} [includeCertChain=true] - включать в результат всю цепочку сертификатов.
  * @param {boolean} [doNotValidate=false] - не проводить валидацию сертификатов.
+ * @param {CADESCOM_CADES_TYPE} [cadesType=CADESCOM_CADES_TYPE.CADESCOM_CADES_BES] - тип усовершенствованной подписи (см. CADESCOM_CADES_TYPE).
  * @throws {CryptoError} в случае ошибки.
  * @returns файл подписи в кодировке Base64.
  */
@@ -33,6 +34,7 @@ export function sign(
   detach: boolean = true,
   includeCertChain: boolean = true,
   doNotValidate: boolean = false,
+  cadesType: CADESCOM_CADES_TYPE = CADESCOM_CADES_TYPE.CADESCOM_CADES_BES,
 ): Promise<string> {
   return afterPluginLoaded(async () => {
     const logData = [];
@@ -124,7 +126,7 @@ export function sign(
         const signResult = await unwrap(
           signedData.SignCades(
             signer,
-            CADESCOM_CADES_TYPE.CADESCOM_CADES_BES,
+            cadesType,
             detach,
           ),
         );

--- a/packages/cryptopro-cades/src/api/signHash.ts
+++ b/packages/cryptopro-cades/src/api/signHash.ts
@@ -51,6 +51,7 @@ function selectAlgoritm(cert: Certificate): CADESCOM_HASH_ALGORITHM {
  *  4A5F6E54CA44064A5544943DDC244DDC84DC3952AC5924A475838E7BB8320878
  * @param {boolean} [includeCertChain=true] - включать в результат всю цепочку сертификатов.
  * @param {boolean} [doNotValidate=false] - не проводить валидацию сертификатов.
+ * @param {CADESCOM_CADES_TYPE} [cadesType=CADESCOM_CADES_TYPE.CADESCOM_CADES_BES] - тип усовершенствованной подписи (см. CADESCOM_CADES_TYPE).
  * @throws {CryptoError} в случае ошибки.
  * @returns файл подписи в кодировке Base64.
  */
@@ -59,6 +60,7 @@ export function signHash(
   data: ArrayBuffer | string,
   includeCertChain: boolean = true,
   doNotValidate: boolean = false,
+  cadesType: CADESCOM_CADES_TYPE = CADESCOM_CADES_TYPE.CADESCOM_CADES_BES,
 ): Promise<string> {
   return afterPluginLoaded(async () => {
     const logData = [];
@@ -147,7 +149,7 @@ export function signHash(
           signedData.SignHash(
             hashedData,
             signer,
-            CADESCOM_CADES_TYPE.CADESCOM_CADES_BES,
+            cadesType,
           ),
         );
 

--- a/packages/cryptopro-cades/src/types/cadesplugin/ICertificate.ts
+++ b/packages/cryptopro-cades/src/types/cadesplugin/ICertificate.ts
@@ -8,6 +8,7 @@ import type { WithOptionalPromise } from '../WithOptionalPromise';
  * Описывает сертификат открытого ключа.
  * @see https://docs.microsoft.com/en-us/windows/win32/seccrypto/certificate
  * @see https://docs.cryptopro.ru/cades/reference/cadescom/cadescom_class/cpcertificate
+ * @see https://docs.cryptopro.ru/cades/reference/cadescom/cadescom_interface/icpcertificate
  */
 export interface ICertificate {
   /**
@@ -82,4 +83,9 @@ export interface ICertificate {
    */
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   IsValid(): WithOptionalPromise<any>;
+
+  /**
+   * Производит поиск закрытого ключа соответствующего сертификату и устанавливает ссылку на него.
+   */
+  FindPrivateKey(): WithOptionalPromise<void>;
 }


### PR DESCRIPTION
Поправил корректное определение наличия контейнера закрытого ключа в системе.

Добавил необязательные параметры функциям получения списка сертификатов, подписи, подписи хэша файла для гибкости работы с ними.